### PR TITLE
Adding check for Windows Server build machines

### DIFF
--- a/prepareWebRtc.bat
+++ b/prepareWebRtc.bat
@@ -376,9 +376,12 @@ POPD
 GOTO:EOF
 
 :updateSDKVersion
-
-FOR /f "tokens=4-7 delims=[.] " %%i IN ('ver') DO (IF %%i==Version (SET v=%%j.%%k.%%l) ELSE (SET v=%%i.%%j.%%k))
-
+systeminfo | findstr "Windows.Server.201[26]"
+IF ERRORLEVEL 1 (
+	FOR /f "tokens=4-7 delims=[.] " %%i IN ('ver') DO (IF %%i==Version (SET v=%%j.%%k.%%l) ELSE (SET v=%%i.%%j.%%k))
+) ELSE (
+	SET v="10.0.10240"
+)
 IF NOT "!v!"=="" (
 	CALL:print %warning% "!v! SDK version will be used"
 	SET SDKVersionString=%stringToUpdateWithSDKVersion:10.0.10240=!v!%


### PR DESCRIPTION
Adding a simple version check for Windows Server hosts that still report actual build numbers 6.3.9600.0 instead of the Windows 10 SDK version namespaces 10.0.xxxxx

This enables Windows Server 2012 R2, 2016, 2016 R2 servers to act as build agents for automation.